### PR TITLE
Removed cfchecker and pinned iris to 1.7.2.

### DIFF
--- a/req.txt
+++ b/req.txt
@@ -3,6 +3,6 @@ mpld3
 pyoos
 qrcode
 geojson
-cfchecker
 utilities
 mplleaflet
+iris=1.7.2_DEV_9e1fd13


### PR DESCRIPTION
This change reflects the use of https://binstar.org/ioos